### PR TITLE
readme: Use Flathub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A counter for GNOME.
 
 ## Installing
 
-Install the stable version of Tally through [Flathub](https://flathub.org/apps/ca.vlacroix.Tally).
+[![Get it on Flathub](https://flathub.org/api/badge?svg&locale=en)](https://flathub.org/apps/ca.vlacroix.Tally)
 
 ## Building
 


### PR DESCRIPTION
Replace the link with a clickable, recognizable [Flathub badge,][1] which is commonly used to link to apps on Flathub from their homepages / README files

[1]: https://flathub.org/badges