### PR TITLE
Make Tally fit on Mobile

### DIFF
--- a/ca.vlacroix.Tally.metainfo.xml
+++ b/ca.vlacroix.Tally.metainfo.xml
@@ -11,6 +11,11 @@
 	<content_rating type="oars-1.1" />
 
 	<releases>
+		<release version="0.4.1" date="2024-11-28">
+			<description>
+				<p>popout: Prevent keepalive bug</p>
+			</description>
+		</release>
 		<release version="0.4" date="2024-11-26">
 			<description>
 				<p>Individual counters can now be shown in separate windows with enlarged text and buttons.</p>
@@ -68,6 +73,9 @@ Various tweaks have been made to improve the user experience:
 	<recommends>
 		<display_length compare="ge">600</display_length>
 	</recommends>
+	<requires>
+		<display_length compare="ge">360</display_length>
+	</requires>
 	<supports>
 		<control>pointing</control>
 		<control>keyboard</control>

--- a/tally.lua
+++ b/tally.lua
@@ -421,8 +421,8 @@ function tally:popout()
 	self.entry:bind_property("text", namelabel, "label", "BIDIRECTIONAL")
 	local countlabel = Gtk.Label {
 		label = ("%d"):format(self.row.value),
-		width_request = 200,
-		margin_end = 24,
+		width_request = 100,
+		margin_end = 12,
 		xalign = 1,
 	}
 	countlabel:add_css_class "numeric"
@@ -780,10 +780,10 @@ local function newwin()
 	local clamp = Adw.Clamp {
 		child = lbox,
 		maximum_size = 600,
-		margin_start = 48,
-		margin_end = 48,
-		margin_top = 24,
-		margin_bottom = 24,
+		margin_start = 24,
+		margin_end = 24,
+		margin_top = 12,
+		margin_bottom = 12,
 	}
 
 	local scroll = Gtk.ScrolledWindow {
@@ -819,8 +819,10 @@ local function newwin()
 		application = app,
 		title = _ "Tally",
 		content = tbview,
-		height_request = 600,
-		width_request = 500,
+		default_height = 600,
+		default_width = 500,
+		height_request = 294,
+		width_request = 360,
 	}
 
 	function infobtn.on_clicked()
@@ -853,8 +855,8 @@ SECTION: Styles
 local cssbase = [[
 .colorselector checkbutton {
 	padding: 0;
-	min-height: 32px;
-	min-width: 32px;
+	min-height: 28px;
+	min-width: 28px;
 	padding: 1px;
 	background-clip: content-box;
 	border-radius: 9999px;


### PR DESCRIPTION
Hi Victoria,

thank you for creating this awesome app!

This PR makes it work on phones that run the GNOME stack, e.g., with Phosh or GNOME Shell Mobile (e.g, with [postmarketOS](https://postmarketos.org), [Mobian](https://mobian.org) or [Droidian](https://droidian.org) ), as 

- I am not aware of another app solving this use-case for mobile yet,
- I felt recording something on a tally is something people would want to do on a handheld, mobile device.

I've tried to alter the UI as little as possible.

I've tried to collect relevant information on https://linuxphoneapps.org/docs/resources/developer-information/, the key factor is that a minimal window width of 360 logical pixels needs to be supported. You don't need a phone to ensure this, see https://blogs.gnome.org/alicem/2024/12/19/mobile-testing-in-libadwaita/.

That said, I am happy to help with testing future releases on mobile. :-)

Cheers,
Peter