### PR TITLE
Icon change for "Select counters to delete" button

### DIFF
--- a/tally.lua
+++ b/tally.lua
@@ -665,7 +665,7 @@ local function newwin()
 		tooltip_text = _ "About Tally",
 	}
 	local checkbtn = Gtk.ToggleButton {
-		icon_name = "checkbox-checked-symbolic",
+		icon_name = "selection-mode-symbolic",
 		tooltip_text = _ "Select counters to delete",
 	}
 


### PR DESCRIPTION
Currently, it uses the `checkbox-checked-symbolic` icon, which feels clunky. The `selection-mode-symbolic` icon is specifically designed for this type of button and fits much better in the application's title bar.